### PR TITLE
Migrate from goServiceLookup to Discovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,13 +50,13 @@ ui:
 	@mkdir ui
 
 ui/ui.go: $(GBD) $(wildcard static/ui/**/*) ui
-	go-bindata -prefix="static/" -o ui/ui.go -pkg=ui static/ui/...
+	$(GBD) -prefix="static/" -o ui/ui.go -pkg=ui static/ui/...
 
 templates:
 	@mkdir templates
 
 templates/templates.go: $(GBD) $(wildcard static/templates/*) templates
-	go-bindata -prefix="static/" -o templates/templates.go -pkg=templates static/templates/...
+	$(GBD) -prefix="static/" -o templates/templates.go -pkg=templates static/templates/...
 
 .PHONY: coverage
 coverage: 

--- a/Makefile
+++ b/Makefile
@@ -11,24 +11,25 @@ GIT     := $(shell git rev-parse --short HEAD)
 DIRTY   := $(shell git diff-index --quiet HEAD 2> /dev/null > /dev/null || echo "-dirty")
 
 
-$(BINARY): deps $(wildcard **/*.go) proto ui/ui.go templates/templates.go
+$(BINARY): $(wildcard **/*.go) proto ui/ui.go templates/templates.go deps
 	@go install -v -ldflags \
 		"-X github.com/wish/eventmaster.Version=$(VERSION)$(V_DIRTY) \
 		 -X github.com/wish/eventmaster.Git=$(GIT)$(DIRTY)" \
 		github.com/wish/eventmaster/cmd/...
 
 .PHONY: proto
-proto: deps proto/eventmaster.pb.go
+proto: proto/eventmaster.pb.go 
 
 proto/eventmaster.pb.go: $(PGG) proto/eventmaster.proto
 	protoc --plugin=${PGG} -I proto/ proto/eventmaster.proto --go_out=plugins=grpc:proto
+	cp proto/github.com/wish/eventmaster/eventmaster.pb.go proto/
 
 .PHONY: test
-test: deps proto/eventmaster.pb.go ui/ui.go templates/templates.go
+test: proto/eventmaster.pb.go ui/ui.go templates/templates.go
 	@go test -cover ${PKGS}
 
 .PHONY: lint
-lint: deps $(GOLINT)
+lint: $(GOLINT)
 	@go vet ${PKGS}
 	@golint -set_exit_status ${PKGS}
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ cluster along with other database options.
 
 Of note if `"cassandra_config":"service_name"` is non-empty then `eventmaster`
 currently uses
-[service lookup](https://github.com/ContextLogic/goServiceLookup)
+[discovery](https://github.com/wish/discovery)
 to find the IPs of the Cassandra cluster.
 
 For example the port of the eventmaster server can be configured using the

--- a/cassandra.go
+++ b/cassandra.go
@@ -51,7 +51,6 @@ func NewCassandraStore(c CassandraConfig) (*CassandraStore, error) {
 		}
 		stringIps := make([]string, len(addrs))
 		for i, addr := range addrs {
-			log.Infof("addr: %s", addr.IP.String())
 			stringIps[i] = addr.IP.String()
 		}
 		cassandraIps = stringIps

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.16
 require (
 	cloud.google.com/go v0.26.0 // indirect
 	github.com/BurntSushi/toml v0.3.1 // indirect
-	github.com/ContextLogic/goServiceLookup v0.0.0-20170420221607-43a14c585a6f
 	github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a // indirect
 	github.com/census-instrumentation/opencensus-proto v0.2.1 // indirect
 	github.com/client9/misspell v0.3.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/julienschmidt/httprouter v1.1.0
 	github.com/kelseyhightower/envconfig v1.3.0
 	github.com/matttproud/golang_protobuf_extensions v1.0.0 // indirect
+	github.com/miekg/dns v1.1.42 // indirect
 	github.com/pkg/errors v0.8.0
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v0.8.0
@@ -35,6 +36,7 @@ require (
 	github.com/sirupsen/logrus v1.0.3
 	github.com/soheilhy/cmux v0.1.3
 	github.com/stretchr/testify v1.5.1
+	github.com/wish/discovery v0.0.0-20190510213300-be3745886c68
 	github.com/xeipuuv/gojsonpointer v0.0.0-20170225233418-6fe8760cad35 // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20150808065054-e02fc20de94c // indirect
 	github.com/xeipuuv/gojsonschema v0.0.0-20170914031516-3f523f4c14b6

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/ContextLogic/goServiceLookup v0.0.0-20170420221607-43a14c585a6f h1:RAya8BdXSg5wh6vDUcbt+p0m29tl+fENlStt7R8HPJo=
-github.com/ContextLogic/goServiceLookup v0.0.0-20170420221607-43a14c585a6f/go.mod h1:WIeQoHn1RytZXT8XRZN+FOnPKm+SbFmrmqKvu2+I7rs=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a h1:BtpsbiV638WQZwhA98cEZw2BsbnQJrbd0BI7tsy0W1c=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,8 @@ github.com/kelseyhightower/envconfig v1.3.0 h1:IvRS4f2VcIQy6j4ORGIf9145T/AsUB+oY
 github.com/kelseyhightower/envconfig v1.3.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/matttproud/golang_protobuf_extensions v1.0.0 h1:YNOwxxSJzSUARoD9KRZLzM9Y858MNGCOACTvCW9TSAc=
 github.com/matttproud/golang_protobuf_extensions v1.0.0/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/miekg/dns v1.1.42 h1:gWGe42RGaIqXQZ+r3WUGEKBEtvPHY2SXo4dqixDNxuY=
+github.com/miekg/dns v1.1.42/go.mod h1:+evo5L0630/F6ca/Z9+GAqzhjGyn8/c+TBaOyfEl0V4=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -88,6 +90,8 @@ github.com/stretchr/testify v1.1.4 h1:ToftOQTytwshuOSj6bDSolVUa3GINfJP/fg3OkkOzQ
 github.com/stretchr/testify v1.1.4/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/wish/discovery v0.0.0-20190510213300-be3745886c68 h1:6p1JlomNSf+RI1+wVhOcEyIKYL1OIHoldd+JauDRa74=
+github.com/wish/discovery v0.0.0-20190510213300-be3745886c68/go.mod h1:2ote7T3IYDlsnATJ5MGne/PxI8eSjqhuRh9prhAuK2c=
 github.com/xeipuuv/gojsonpointer v0.0.0-20170225233418-6fe8760cad35 h1:0TnXeVP6mx+A4CBf8cQVkQfkhyGBQCmJcT4g6zKzm7M=
 github.com/xeipuuv/gojsonpointer v0.0.0-20170225233418-6fe8760cad35/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20150808065054-e02fc20de94c h1:XZWnr3bsDQWAZg4Ne+cPoXRPILrNlPNQfxBuwLl43is=
@@ -119,6 +123,7 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4 h1:b0LrWgu8+q7z4J+0Y3Umo5q1dL7NXBkKBWkaVkAq17E=
 golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -126,6 +131,7 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170922123423-429f518978ab h1:/SnMvMu4DHNz3T1J051qLvBpT2Wq57ymgrs7ouudGkY=
 golang.org/x/sys v0.0.0-20170922123423-429f518978ab/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -135,6 +141,7 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210303074136-134d130e1a04/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4 h1:EZ2mChiOa8udjfp6rRmswTbtZN/QzUQp4ptM4rnjHvc=
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
Result is verified by comparing the IP address obtained by both goServiceLookup and Discovery.

Discovery:
```
root@8c24dad45c0c:/go/src/github.com/wish/eventmaster# eventmaster 
INFO[0000] Connecting to cassandra: [10.10.2.230 10.10.2.108] 
```
goServiceLookup:
```
root@2f2754232d77:/go/src/github.com/wish/eventmaster# eventmaster 
INFO[0001] Connecting to cassandra: [10.10.2.108 10.10.2.230]
```

Consul FQDN generated by `goServiceLookup.GenerateServiceName` is `cassandra-client.service.consul.`. Since goServiceLookup is deprecated, the identical FQDN is reconstructed manually.