### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.16.5
+
+RUN apt-get update -q
+RUN apt-get install -y protobuf-compiler
+
+COPY . /go/src/github.com/wish/eventmaster
+WORKDIR /go/src/github.com/wish/eventmaster
+
+RUN make
+
+EXPOSE 50052
+CMD ["eventmaster"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,7 @@ WORKDIR /go/src/github.com/wish/eventmaster
 RUN make
 
 EXPOSE 50052
-CMD ["eventmaster"]
+
+RUN mkdir /app
+WORKDIR /app
+CMD ["eventmaster","-c","config.json"]


### PR DESCRIPTION
This PR adds Dockerfile to eventmaster. Image can be built by
```
docker build . -t em
```
To run the eventmaster in a container:
```
docker run --rm -v /your/path/to/config.json:/app/config.json -p50052:50052 em
```