### PR TITLE
Add Postgres as a database option

### DIFF
--- a/cmd/eventmaster/config.go
+++ b/cmd/eventmaster/config.go
@@ -12,6 +12,7 @@ import (
 type EMConfig struct {
 	DataStore      string             `json:"data_store"`
 	CassConfig     em.CassandraConfig `json:"cassandra_config"`
+	PostgresConfig em.PostgresConfig  `json:"postgres_config"`
 	UpdateInterval int                `json:"update_interval"`
 }
 

--- a/cmd/eventmaster/eventmaster.go
+++ b/cmd/eventmaster/eventmaster.go
@@ -55,6 +55,11 @@ func main() {
 		if err != nil {
 			log.Fatalf("failed to create cassandra data store: %v", err)
 		}
+	} else if emConf.DataStore == "postgres" {
+		ds, err = em.NewPostgresStore(emConf.PostgresConfig)
+		if err != nil {
+			log.Fatalf("failed to create postgres data store: %v", err)
+		}
 	} else {
 		log.Fatalf("Unrecognized data store option")
 	}

--- a/docs/api/readme.md
+++ b/docs/api/readme.md
@@ -223,7 +223,7 @@ POST /v1/dc
 Accept: application/json
 Content-Type: application/json
 {
-	"dc": "dc1"
+	"DC_name": "dc1"
 }
 ```
 
@@ -247,7 +247,7 @@ PUT /v1/dc/dc1
 Accept: application/json
 Content-Type: application/json
 {
-	"dc": "dc3"
+	"DC_name": "dc3"
 }
 ```
 

--- a/etc/eventmaster.json
+++ b/etc/eventmaster.json
@@ -1,5 +1,12 @@
 {
-  "data_store": "cassandra",
+  "data_store": "postgres",
+  "postgres_config": {
+    "addr": "127.0.0.1",
+    "port": 5432,
+    "database": "eventmaster",
+    "username": "postgres",
+    "password": "password"
+  },
   "cassandra_config": {
     "addrs": ["127.0.0.1:9042"],
     "keyspace": "event_master",

--- a/event_store.go
+++ b/event_store.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"github.com/segmentio/ksuid"
 	"github.com/xeipuuv/gojsonschema"
 
@@ -326,7 +326,7 @@ func (es *EventStore) AddEvent(event *UnaddedEvent) (string, error) {
 
 	if err = es.ds.AddEvent(evt); err != nil {
 		metrics.DBError("write")
-		return "", errors.Wrap(err, "Error executing insert query in Cassandra")
+		return "", errors.Wrap(err, "Error executing insert query")
 	}
 
 	return evt.EventID, nil
@@ -462,7 +462,7 @@ func (es *EventStore) UpdateTopic(oldName string, td Topic) (string, error) {
 		Schema: schemaStr,
 	}); err != nil {
 		metrics.DBError("write")
-		return "", errors.Wrap(err, "Error executing update query in Cassandra")
+		return "", errors.Wrap(err, "Error executing update query")
 	}
 
 	es.topicMutex.Lock()
@@ -493,7 +493,7 @@ func (es *EventStore) DeleteTopic(deleteReq *eventmaster.DeleteTopicRequest) err
 
 	if err := es.ds.DeleteTopic(id); err != nil {
 		metrics.DBError("write")
-		return errors.Wrap(err, "Error executing delete query in Cassandra")
+		return errors.Wrap(err, "Error executing delete query")
 	}
 
 	es.topicMutex.Lock()

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/jteeuwen/go-bindata v3.0.8-0.20180305030458-6025e8de665b+incompatible // indirect
 	github.com/julienschmidt/httprouter v1.1.0
 	github.com/kelseyhightower/envconfig v1.3.0
+	github.com/lib/pq v1.10.2
 	github.com/matttproud/golang_protobuf_extensions v1.0.0 // indirect
 	github.com/miekg/dns v1.1.42 // indirect
 	github.com/pkg/errors v0.8.0

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,10 @@ go 1.16
 require (
 	cloud.google.com/go v0.26.0 // indirect
 	github.com/BurntSushi/toml v0.3.1 // indirect
+	github.com/Masterminds/squirrel v1.5.0
 	github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a // indirect
 	github.com/census-instrumentation/opencensus-proto v0.2.1 // indirect
 	github.com/client9/misspell v0.3.4 // indirect
-	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/elazarl/go-bindata-assetfs v1.0.0
 	github.com/envoyproxy/protoc-gen-validate v0.1.0 // indirect
 	github.com/gocql/gocql v0.0.0-20210515062232-b7ef815b4556

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/Masterminds/squirrel v1.5.0 h1:JukIZisrUXadA9pl3rMkjhiamxiB0cXiu+HGp/Y8cY8=
+github.com/Masterminds/squirrel v1.5.0/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a h1:BtpsbiV638WQZwhA98cEZw2BsbnQJrbd0BI7tsy0W1c=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932/go.mod h1:NOuUCSz6Q9T7+igc/hlvDOUdtWKryOrtFyIVABv/p7k=
@@ -9,6 +11,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/elazarl/go-bindata-assetfs v1.0.0 h1:G/bYguwHIzWq9ZoyUQqrjTmJbbYn3j3CKKpKinvZLFk=
 github.com/elazarl/go-bindata-assetfs v1.0.0/go.mod h1:v+YaWX3bdea5J/mo8dSETolEo7R71Vk1u8bnjau5yw4=
 github.com/envoyproxy/go-control-plane v0.7.1/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=
@@ -62,6 +66,10 @@ github.com/kelseyhightower/envconfig v1.3.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 h1:SOEGU9fKiNWd/HOJuq6+3iTQz8KNCLtVX6idSoTLdUw=
+github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=
+github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 h1:P6pPBnrTSX3DEVR4fDembhRWSsG5rVo6hYhAB/ADZrk=
+github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6FmdpVm2joNMFikkuWg0EoCKLGUMNw=
 github.com/lib/pq v1.10.2 h1:AqzbZs4ZoCBp+GtejcpCpcxM3zlSMx29dXbUSeVtJb8=
 github.com/lib/pq v1.10.2/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/matttproud/golang_protobuf_extensions v1.0.0 h1:YNOwxxSJzSUARoD9KRZLzM9Y858MNGCOACTvCW9TSAc=
@@ -95,6 +103,7 @@ github.com/soheilhy/cmux v0.1.3/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4k
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.1.4 h1:ToftOQTytwshuOSj6bDSolVUa3GINfJP/fg3OkkOzQQ=
 github.com/stretchr/testify v1.1.4/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/kelseyhightower/envconfig v1.3.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/lib/pq v1.10.2 h1:AqzbZs4ZoCBp+GtejcpCpcxM3zlSMx29dXbUSeVtJb8=
+github.com/lib/pq v1.10.2/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/matttproud/golang_protobuf_extensions v1.0.0 h1:YNOwxxSJzSUARoD9KRZLzM9Y858MNGCOACTvCW9TSAc=
 github.com/matttproud/golang_protobuf_extensions v1.0.0/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.1.42 h1:gWGe42RGaIqXQZ+r3WUGEKBEtvPHY2SXo4dqixDNxuY=

--- a/postgres.go
+++ b/postgres.go
@@ -125,9 +125,9 @@ func (p *PostgresStore) AddDC(dc DC) error {
 	return nil
 }
 
-func (p *PostgresStore) UpdateDC(string, string) error {
-	// TODO: implement this function
-	return nil
+func (p *PostgresStore) UpdateDC(id string, newName string) error {
+	_, err := p.db.Exec("UPDATE event_dc SET dc=$1 WHERE dc_id=$2", newName, id)
+	return err
 }
 
 func (p *PostgresStore) CloseSession() {

--- a/postgres.go
+++ b/postgres.go
@@ -1,0 +1,111 @@
+package eventmaster
+
+import (
+	"database/sql"
+	"fmt"
+
+	_ "github.com/lib/pq"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	eventmaster "github.com/wish/eventmaster/proto"
+)
+
+// implements datastore
+type PostgresStore struct {
+	db *sql.DB
+}
+
+type PostgresConfig struct {
+	Addr        string `json:"addr"`
+	Port        int    `json:"port"`
+	Database    string `json:"database"`
+	ServiceName string `json:"service_name"`
+	Username    string `json:"username"`
+	Password    string `json:"password"`
+}
+
+func NewPostgresStore(c PostgresConfig) (*PostgresStore, error) {
+	var host string
+	if c.ServiceName != "" {
+		host = c.ServiceName + ".service.consul"
+	} else {
+		host = c.Addr
+	}
+	log.Infof("Connecting to postgres: %v", host)
+	psqlInfo := fmt.Sprintf("host=%s port=%d user=%s "+
+		"password=%s dbname=%s sslmode=disable",
+		host, c.Port, c.Username, c.Password, c.Database)
+	db, err := sql.Open("postgres", psqlInfo)
+	if err != nil {
+		return nil, errors.Wrap(err, "Error creating postgres session")
+	}
+	err = db.Ping()
+	if err != nil {
+		return nil, errors.Wrap(err, "Error creating postgres session")
+	}
+	log.Infof("Successfully connected to postgres %s", host)
+
+	return &PostgresStore{
+		db: db,
+	}, nil
+}
+
+func (p *PostgresStore) AddEvent(*Event) error {
+	// TODO: implement this function
+	return nil
+}
+
+func (p *PostgresStore) Find(q *eventmaster.Query, topicIDs []string, dcIDs []string) (Events, error) {
+	// TODO: implement this function
+	return nil, nil
+}
+
+func (p *PostgresStore) FindByID(string, bool) (*Event, error) {
+	// TODO: implement this function
+	return nil, nil
+}
+
+func (p *PostgresStore) FindIDs(*eventmaster.TimeQuery, HandleEvent) error {
+	// TODO: implement this function
+	return nil
+}
+
+func (p *PostgresStore) GetTopics() ([]Topic, error) {
+	// TODO: implement this function
+	return nil, nil
+}
+
+func (p *PostgresStore) AddTopic(RawTopic) error {
+	// TODO: implement this function
+	return nil
+}
+
+func (p *PostgresStore) UpdateTopic(RawTopic) error {
+	// TODO: implement this function
+	return nil
+}
+
+func (p *PostgresStore) DeleteTopic(string) error {
+	// TODO: implement this function
+	return nil
+}
+
+func (p *PostgresStore) GetDCs() ([]DC, error) {
+	// TODO: implement this function
+	return nil, nil
+}
+
+func (p *PostgresStore) AddDC(DC) error {
+	// TODO: implement this function
+	return nil
+}
+
+func (p *PostgresStore) UpdateDC(string, string) error {
+	// TODO: implement this function
+	return nil
+}
+
+func (p *PostgresStore) CloseSession() {
+	// TODO: implement this function
+	return
+}

--- a/postgres.go
+++ b/postgres.go
@@ -91,8 +91,25 @@ func (p *PostgresStore) DeleteTopic(string) error {
 }
 
 func (p *PostgresStore) GetDCs() ([]DC, error) {
-	// TODO: implement this function
-	return nil, nil
+	rows, err := p.db.Query("SELECT dc_id, dc from event_dc")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var dcs []DC
+
+	var dc_id, dc string
+	for rows.Next() {
+		err = rows.Scan(&dc_id, &dc)
+		if err != nil {
+			return nil, err
+		}
+		dcs = append(dcs, DC{
+			ID:   dc_id,
+			Name: dc,
+		})
+	}
+	return dcs, nil
 }
 
 func (p *PostgresStore) AddDC(dc DC) error {
@@ -102,7 +119,7 @@ func (p *PostgresStore) AddDC(dc DC) error {
 	}
 	_, err = stmt.Exec(dc.ID, dc.Name)
 	if err != nil {
-		return errors.Wrap(err, "Failed executing insert DC statement")
+		return err
 	}
 
 	return nil

--- a/postgres.go
+++ b/postgres.go
@@ -131,6 +131,5 @@ func (p *PostgresStore) UpdateDC(string, string) error {
 }
 
 func (p *PostgresStore) CloseSession() {
-	// TODO: implement this function
-	return
+	p.db.Close()
 }

--- a/postgres.go
+++ b/postgres.go
@@ -95,8 +95,16 @@ func (p *PostgresStore) GetDCs() ([]DC, error) {
 	return nil, nil
 }
 
-func (p *PostgresStore) AddDC(DC) error {
-	// TODO: implement this function
+func (p *PostgresStore) AddDC(dc DC) error {
+	stmt, err := p.db.Prepare("INSERT INTO event_dc (dc_id, dc) VALUES ($1, $2)")
+	if err != nil {
+		return errors.Wrap(err, "Failed preparing insert DC statement")
+	}
+	_, err = stmt.Exec(dc.ID, dc.Name)
+	if err != nil {
+		return errors.Wrap(err, "Failed executing insert DC statement")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This PR adds Postgres as a database option. Connection details can be specified in the config file.

Major changes are implemented in `postgres.go`. This file implements the `DataStore` protocol, therefore hot-swappable with existing Cassandra implementation. See `event_store.go` for details

`func NewPostgresStore(c PostgresConfig) (*PostgresStore, error)`: Connect to a new Postgres DB

`func (p *PostgresStore) AddEvent(e *Event) error`: Add a new event to DB

`func getPlaceHolderArray(slice []string) string`: Helper method, returns a string of placeholders that matches the length of the input array for Postgres (like [?, ?, ..., ?])

`func stringsToIfaces(in []string) []interface{}`: Helper method to convert `[]string` to `[]interface{}`

`func (p *PostgresStore) Find(q *eventmaster.Query, topicIDs []string, dcIDs []string) (Events, error)`: Find event entries that matches given constraints

`func (p *PostgresStore) FindByID(id string, inclData bool) (*Event, error)`: Find event entry of a specific ID

`func (p *PostgresStore) FindIDs(query *eventmaster.TimeQuery, handle HandleEvent)`: Find event entry IDs that matches given time constraint

`func (p *PostgresStore) GetTopics() ([]Topic, error)`: Get all topics

`func (p *PostgresStore) AddTopic(t RawTopic) error`: Add a topic

`func (p *PostgresStore) UpdateTopic(t RawTopic) error`: Update a topic

`func (p *PostgresStore) DeleteTopic(id string) error`: Delete a topic

`func (p *PostgresStore) GetDCs() ([]DC, error)`: Get all datacenters

`func (p *PostgresStore) AddDC(dc DC) error`: Add a datacenter

`func (p *PostgresStore) UpdateDC(id string, newName string) error`: Update a datacenter

`func (p *PostgresStore) CloseSession()`: Close the DB session