### PR TITLE
Change URL route due to an undocumented Grafana API change

### DIFF
--- a/server.go
+++ b/server.go
@@ -104,7 +104,7 @@ func registerRoutes(srv *Server) http.Handler {
 	// grafana datasource endpoints
 	r.GET("/grafana", latency("/grafana", cors(srv.grafanaOK)))
 	r.GET("/grafana/", latency("/grafana/", cors(srv.grafanaOK)))
-	r.OPTIONS("/grafana/:route", latency("/grafana", cors(srv.grafanaOK)))
+	r.OPTIONS("/grafana/*route", latency("/grafana", cors(srv.grafanaOK)))
 	r.POST("/grafana/annotations", latency("/grafana/annotations", cors(srv.grafanaAnnotations)))
 	r.POST("/grafana/search", latency("/grafana/search", cors(srv.grafanaSearch)))
 


### PR DESCRIPTION
According to [grafana documentation](https://grafana.com/grafana/plugins/simpod-json-datasource/), only `/grafana/annotations` needs to implement the `OPTIONS` method. However for some reasons (probably undocumented API change) `/grafana` will get `OPTIONS` requests and will fail. Using a catch-all parameter as a fix. This is safe, since no parameter is used and the response is just HTTP OK.