### PR TITLE
Add -go_opt=paths=source_relative to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,7 @@ $(BINARY): $(wildcard **/*.go) proto ui/ui.go templates/templates.go deps
 proto: proto/eventmaster.pb.go 
 
 proto/eventmaster.pb.go: $(PGG) proto/eventmaster.proto
-	protoc --plugin=${PGG} -I proto/ proto/eventmaster.proto --go_out=plugins=grpc:proto
-	cp proto/github.com/wish/eventmaster/eventmaster.pb.go proto/
+	protoc --plugin=${PGG} -I proto/ proto/eventmaster.proto --go_out=plugins=grpc:proto -go_opt=paths=source_relative
 
 .PHONY: test
 test: proto/eventmaster.pb.go ui/ui.go templates/templates.go

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ $(BINARY): $(wildcard **/*.go) proto ui/ui.go templates/templates.go deps
 proto: proto/eventmaster.pb.go 
 
 proto/eventmaster.pb.go: $(PGG) proto/eventmaster.proto
-	protoc --plugin=${PGG} -I proto/ proto/eventmaster.proto --go_out=plugins=grpc:proto -go_opt=paths=source_relative
+	protoc --plugin=${PGG} -I proto/ proto/eventmaster.proto --go_out=plugins=grpc:proto --go_opt=paths=source_relative
 
 .PHONY: test
 test: proto/eventmaster.pb.go ui/ui.go templates/templates.go


### PR DESCRIPTION
This PR adds `-go_opt=paths=source_relative` param to the `protoc-gen-go` command in Makefile to avoid extra copy.