### PR TITLE
Configure CI to run and push for all published releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ on:
   pull_request:
     branches:
       - master
+  release:
+    types: [published]
 
 jobs:
 
@@ -33,7 +35,7 @@ jobs:
           password: '${{ secrets.QUAYIO_PASSWORD }}'
       -
         name: Run Buildx and push
-        if: ${{ github.event_name == 'push'}}
+        if: ${{ github.event_name != 'pull_request' }}
         run: |
           docker buildx build \
             --platform linux/amd64 \


### PR DESCRIPTION
This PR enables the CI to be executed and push compiled image to Quay when a release is published. Both stable releases and pre-releases are included.