### PR TITLE
Login to Quay for all CI actions other than pull request

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
       -
         name: Login
-        if: ${{ github.event_name == 'push'}}
+        if: ${{ github.event_name != 'pull_request'}}
         uses: azure/docker-login@v1
         with:
           login-server: quay.io


### PR DESCRIPTION
Login to Quay for all CI actions other than pull request

This solves CI error that shows 401 unauthorized from Quay