### PR TITLE
Fix bug causing supersets to be handled incorrectly

### DIFF
--- a/postgres.go
+++ b/postgres.go
@@ -222,7 +222,7 @@ func (p *PostgresStore) Find(q *eventmaster.Query, topicIDs []string, dcIDs []st
 		var op string
 		if q.TagAndOperator {
 			// LHS array is the superset of RHS array
-			op = ">&"
+			op = "@>"
 		} else {
 			// LHS array has interestion with RHS array
 			op = "&&"


### PR DESCRIPTION
A SQL statement used to filter tags contains a bug causing supersets to be handed incorrectly. Fixed in the PR.