### PR TITLE
Add max_db_conn_count field to limit DB connection counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ To connect to a Postgres database, serveral fields have to be set in the configr
     - `database`: the name of the database
     - `username`: the username of the user with necessary permission to connect/read/write, and
     - `password`: the password of the user (ommited if Vault integration is turned on)
+    - `max_db_conn_count`: maximum database connections allowed (defaulted to be 128)
 
     Additionally, you may choose to toggle integration with HasiCorp Vault. This allows Eventmaster to obtain database password from Vault instead of leaving them as plain-text in the filesystem. Only v2 is supported currently. To do so, set the following fields:
     - `vault`: object containing Vault config

--- a/postgres.go
+++ b/postgres.go
@@ -27,13 +27,14 @@ type VaultConfig struct {
 }
 
 type PostgresConfig struct {
-	Addr        string      `json:"addr"`
-	Port        int         `json:"port"`
-	Database    string      `json:"database"`
-	ServiceName string      `json:"service_name"`
-	Username    string      `json:"username"`
-	Password    string      `json:"password"`
-	Vault       VaultConfig `json:"vault"`
+	Addr           string      `json:"addr"`
+	Port           int         `json:"port"`
+	Database       string      `json:"database"`
+	ServiceName    string      `json:"service_name"`
+	Username       string      `json:"username"`
+	Password       string      `json:"password"`
+	Vault          VaultConfig `json:"vault"`
+	MaxDbConnCount int         `json:"max_dc_conn_count`
 }
 
 func getPasswordFromVault(c VaultConfig) (*string, error) {
@@ -107,6 +108,14 @@ func NewPostgresStore(c PostgresConfig) (*PostgresStore, error) {
 		log.Errorf(err.Error())
 		return nil, errors.Wrap(err, "Error creating postgres session")
 	}
+
+	connCount := 128
+	if c.MaxDbConnCount != 0 {
+		connCount = c.MaxDbConnCount
+	}
+	db.SetMaxOpenConns(connCount)
+	log.Infof("Set max DB connection count to %d", connCount)
+
 	log.Infof("Successfully connected to postgres %s", host)
 
 	return &PostgresStore{


### PR DESCRIPTION
If the field is not set, default connections allowed to be 128